### PR TITLE
Fix SeedException URL

### DIFF
--- a/src/main/resources/META-INF/errors/org.seedstack.jpa.internal.JpaErrorCode.properties
+++ b/src/main/resources/META-INF/errors/org.seedstack.jpa.internal.JpaErrorCode.properties
@@ -8,10 +8,10 @@
 
 ACCESSING_ENTITY_MANAGER_OUTSIDE_TRANSACTION.message = No active transaction when accessing JPA EntityManager.
 ACCESSING_ENTITY_MANAGER_OUTSIDE_TRANSACTION.fix = Be sure to specify a transactional context using the "@Transactional" annotation before using an entityManager.
-ACCESSING_ENTITY_MANAGER_OUTSIDE_TRANSACTION.url = http://www.seedstack.org/docs/seed/manual/persistence/jpa/#using-the-entity-manager
+ACCESSING_ENTITY_MANAGER_OUTSIDE_TRANSACTION.url = http://seedstack.org/addons/jpa/#using-the-entity-manager
 NO_PERSISTED_CLASSES_IN_UNIT.message = No classes were found belonging to JPA unit "${unit}".
 NO_PERSISTED_CLASSES_IN_UNIT.fix = Verify that the classes are correctly scanned and they are configured to belong to the JPA unit "${unit}".
-NO_PERSISTED_CLASSES_IN_UNIT.url = http://www.seedstack.org/docs/seed/manual/persistence/jpa/#without-persistence-xml
+NO_PERSISTED_CLASSES_IN_UNIT.url = http://seedstack.org/addons/jpa/#without-persistence-xml
 DATA_SOURCE_NOT_FOUND.message = The specified datasource "${datasource}" was not found for JPA unit "${unit}".
 DATA_SOURCE_NOT_FOUND.fix = Verify the datasource name specified in the "org.seedstack.seed.persistence.jpa.unit.${unit}.datasource" configuration property.
-DATA_SOURCE_NOT_FOUND.url = http://www.seedstack.org/docs/seed/manual/persistence/jpa/#without-persistence-xml
+DATA_SOURCE_NOT_FOUND.url = http://seedstack.org/addons/jpa/#without-persistence-xml


### PR DESCRIPTION
The `SeedException` was pointing to the old documentation which leads to a 404 error.